### PR TITLE
Add default FPS handling and unit test

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+from utils import datasets
+
+class DummyCapture:
+    def __init__(self):
+        self.width = 640
+        self.height = 480
+        self.opened_calls = 0
+    def isOpened(self):
+        self.opened_calls += 1
+        return self.opened_calls == 1
+    def get(self, prop):
+        if prop == datasets.cv2.CAP_PROP_FRAME_WIDTH:
+            return self.width
+        if prop == datasets.cv2.CAP_PROP_FRAME_HEIGHT:
+            return self.height
+        if prop == datasets.cv2.CAP_PROP_FPS:
+            return 0
+        return 0
+    def read(self):
+        return True, np.zeros((self.height, self.width, 3), dtype=np.uint8)
+    def grab(self):
+        pass
+    def retrieve(self):
+        return self.read()
+
+class DummyThread:
+    def __init__(self, target, args=(), daemon=None):
+        self.target = target
+        self.args = args
+    def start(self):
+        pass
+
+def test_loadstreams_defaults_fps(monkeypatch):
+    dummy_cap = DummyCapture()
+    monkeypatch.setattr(datasets.cv2, 'VideoCapture', lambda x: dummy_cap)
+    monkeypatch.setattr(datasets, 'Thread', DummyThread)
+    monkeypatch.setattr(datasets, 'letterbox', lambda img, *a, **k: (img, (1, 1), (0, 0)))
+    monkeypatch.setattr(datasets.time, 'sleep', lambda x: None)
+
+    loader = datasets.LoadStreams('dummy.mp4')
+    assert loader.fps == 30
+
+    # Should not raise ZeroDivisionError even though CAP_PROP_FPS returned 0
+    loader.update(0, dummy_cap)

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -290,7 +290,9 @@ class LoadStreams:  # multiple IP or RTSP cameras
             assert cap.isOpened(), f'Failed to open {s}'
             w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
             h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-            self.fps = cap.get(cv2.CAP_PROP_FPS) % 100
+            fps = cap.get(cv2.CAP_PROP_FPS)
+            fps = 30 if not fps else fps
+            self.fps = fps % 100
 
             _, self.imgs[i] = cap.read()  # guarantee first frame
             thread = Thread(target=self.update, args=([i, cap]), daemon=True)


### PR DESCRIPTION
## Summary
- default `LoadStreams` fps to 30 when camera fps is 0
- add regression test for default fps behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f6c4f50288329b6352cbe1715ad65